### PR TITLE
Makefile: Do not generate proto by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,16 +151,10 @@ DEFINES   += U2F_PROXY_MAGIC=\"TRX\"
 DEFINES   += HAVE_IO_U2F HAVE_U2F
 DEFINES   += U2F_REQUEST_TIMEOUT=28000 # 28 seconds
 
-.DEFAULT_GOAL := build_with_proto
-.PHONY: build_with_proto
-build_with_proto: proto
-	$(MAKE) bin/app.elf
-
-all: proto
 proto:
 	$(MAKE) -C $@
 
-.PHONY: all proto
+.PHONY: proto
 
 # nanopb
 include nanopb/extra/nanopb.mk


### PR DESCRIPTION
This is not an issue for build as proto files are commit

This could be revert later with:
- Removing proto file from git
- Using APP_CUSTOM_PREBUILD_TARGETS instead of app Makefile hacks